### PR TITLE
MessageのupdateAtの型の修正

### DIFF
--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -24,7 +24,7 @@ export type Message<T> = {
   /**
    * 管理画面上で表示される更新日時です。
    */
-  updatedAt?: string;
+  updatedAt?: string | Date;
 
   /**
    * コンテンツ API のレスポンスとして使われる値です。


### PR DESCRIPTION
MessageのupdatedAtがstringしか受け付けていないので修正しました。
この型が仕様的にstringのみが正しいのであれば、Read.MEの修正が必要そうです。
`packages/api` の `updatedAt` の以下の部分
```
    /**
     * Update time to be displayed on the admin page.
     * string or Date. optional.
     */
    updatedAt: "2022-04-26T00:27:13.176Z",
```
の `or Date` の部分を削除

