### PR TITLE
useFieldExtensionのレスポンスの型を指定できるようにする

### DIFF
--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -52,7 +52,7 @@ export type GetDefaultDataMessage = {
 
     action: "MICROCMS_GET_DEFAULT_DATA";
 
-    message?: Partial<Message<unknown>>;
+    message?: Partial<Message<any>>;
 
     user: User;
   };

--- a/packages/react/index.ts
+++ b/packages/react/index.ts
@@ -11,7 +11,7 @@ import {
 type UseFieldExtension = <T>(initialState: T, option: SetupOption) => UseFieldExtensionReturnValue<T>;
 
 type UseFieldExtensionReturnValue<T> = {
-  data: unknown;
+  data: T;
   sendMessage: (message: Message<T>) => void;
   user: User;
 };
@@ -19,7 +19,7 @@ type UseFieldExtensionReturnValue<T> = {
 export const useFieldExtension: UseFieldExtension = <T>(initialState: T, option: SetupOption) => {
   const [id, setId] = useState<string>("");
   const [user, setUser] = useState<User>({ email: "" });
-  const [data, setData] = useState<unknown>(initialState);
+  const [data, setData] = useState<T>(initialState);
 
   useEffect(() => {
     const detach = setupFieldExtension({


### PR DESCRIPTION
Reactパッケージ `useFieldExtension` フックのレスポンスの型推論も効くと嬉しいです。
レスポンスの型もGenericsで指定するように修正しました。

が、もし微妙だったらCLOSEしちゃってください✊