### PR TITLE
READMEにインストールガイドを追加

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -6,6 +6,12 @@ This library is for communicating with the microCMS iframe field via `postMessag
 
 This library do not depend framework (eg React, Vue.js ...).
 
+## install
+
+```sh
+  npm install microcms-field-extension-api
+```
+
 ## Usage
 
 ```js

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -6,10 +6,10 @@ This library is for communicating with the microCMS iframe field via `postMessag
 
 This library do not depend framework (eg React, Vue.js ...).
 
-## install
+## Install
 
 ```sh
-  npm install microcms-field-extension-api
+npm install microcms-field-extension-api
 ```
 
 ## Usage

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -6,10 +6,10 @@ This library is for communicating with the microCMS iframe field via `postMessag
 
 This library is useful when using React.
 
-## install
+## Install
 
 ```sh
-  npm install microcms-field-extension-api microcms-field-extension-react
+npm install microcms-field-extension-api microcms-field-extension-react
 ```
 
 ## Usage

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -6,6 +6,12 @@ This library is for communicating with the microCMS iframe field via `postMessag
 
 This library is useful when using React.
 
+## install
+
+```sh
+  npm install microcms-field-extension-api microcms-field-extension-react
+```
+
 ## Usage
 
 ```jsx


### PR DESCRIPTION
インストールガイドがあると親切だと思い、`api` と `react` パッケージに追加しました。
（reactを使おうとしていてapiも必要なことにあとで気づき少しハマりました）