### PR TITLE
[add] 住所補完のサンプルでdescriptionも返すようにする

### DIFF
--- a/examples/address-from-zipcode/app/page.tsx
+++ b/examples/address-from-zipcode/app/page.tsx
@@ -14,6 +14,8 @@ type Address = {
 
 const origin = process.env.NEXT_PUBLIC_MICROCMS_ORIGIN || "https://xxxx.microcms.io";
 
+const TITLE = "住所";
+
 const formatAddressString = (data: Address) => {
   return `${data.postalCode} ${data.prefecture}${data.city}${data.town}`;
 };
@@ -68,6 +70,7 @@ export default function AddressFromZipcode() {
         };
 
         sendMessage({
+          title: TITLE,
           description: formatAddressString(data),
           data,
         });
@@ -104,6 +107,7 @@ export default function AddressFromZipcode() {
     }
 
     sendMessage({
+      title: TITLE,
       description: formatAddressString(newData),
       data: newData,
     });

--- a/examples/address-from-zipcode/app/page.tsx
+++ b/examples/address-from-zipcode/app/page.tsx
@@ -14,6 +14,10 @@ type Address = {
 
 const origin = process.env.NEXT_PUBLIC_MICROCMS_ORIGIN || "https://xxxx.microcms.io";
 
+const formatAddressString = (data: Address) => {
+  return `${data.postalCode} ${data.prefecture}${data.city}${data.town}`;
+};
+
 export default function AddressFromZipcode() {
   const { data, sendMessage } = useFieldExtension<Address>("" as any, {
     origin: origin,
@@ -56,13 +60,16 @@ export default function AddressFromZipcode() {
         setCity(result.address2);
         setTown(result.address3);
 
+        const data = {
+          postalCode: normalizedPostalCode,
+          prefecture: result.address1,
+          city: result.address2,
+          town: result.address3,
+        };
+
         sendMessage({
-          data: {
-            postalCode: normalizedPostalCode,
-            prefecture: result.address1,
-            city: result.address2,
-            town: result.address3,
-          },
+          description: formatAddressString(data),
+          data,
         });
       } else {
         setError("該当する住所が見つかりませんでした。");
@@ -96,7 +103,10 @@ export default function AddressFromZipcode() {
         break;
     }
 
-    sendMessage({ data: newData });
+    sendMessage({
+      description: formatAddressString(newData),
+      data: newData,
+    });
   };
 
   return (


### PR DESCRIPTION
* `examples` の `address-from-zipcode`（郵便番号入力で住所を自動補完する拡張フィールド）に対し、descriptionに郵便番号と住所を設定する処理を追加しました
* これまでコンテンツ一覧で「あり」と表示されていた部分に、郵便番号と住所が表示されるようになります
* 
![image](https://github.com/user-attachments/assets/2ff8c3a8-2957-4f8c-b6e0-33eace052681)
